### PR TITLE
python3 compatibility fix

### DIFF
--- a/superman/file_io/rruff.py
+++ b/superman/file_io/rruff.py
@@ -23,7 +23,7 @@ def parse(fh, return_comments=False):
     if not m:
       raise ValueError('Failed to parse line:\n' + line)
     try:
-      data.append(map(float, m.groups()))
+      data.append([float(n) for n in m.groups()])
     except ValueError:
       pass  # TODO: do something here
   # clean up / validate


### PR DESCRIPTION
in python 3, map creates an iterator object of type map. np.array does not work on these